### PR TITLE
ADD .p8l support

### DIFF
--- a/ftdetect/pico8.vim
+++ b/ftdetect/pico8.vim
@@ -1,1 +1,1 @@
-au! BufRead,BufNewFile *.p8 setfiletype pico8
+au! BufRead,BufNewFile *.p8,*.p8l setfiletype pico8


### PR DESCRIPTION
Adds support for *.p8l files. This extension is generated by Pico-8 when you `printh` to an output file. The `.p8l` format has no spec and is just a text file, but "p8l" implies that it's shorthand for "p8lua". I believe it's useful to have a dedicated file format for use with `#include`; with a different extension than `.p8`, which implies a file containing a working Pico-8 cart; or `.lua` which causes syntax highlighting problems when using Pico-8 shorthand. ps, thank you for this great plugin!!!